### PR TITLE
Producer process

### DIFF
--- a/lib/elsa.ex
+++ b/lib/elsa.ex
@@ -15,6 +15,8 @@ defmodule Elsa do
 
   defdelegate produce_sync(endpoints, topic, partition, key, value), to: Elsa.Producer
 
+  defdelegate produce_sync(pid, key, value), to: Elsa.Producer
+
   def fetch() do
   end
 

--- a/lib/elsa.ex
+++ b/lib/elsa.ex
@@ -13,7 +13,7 @@ defmodule Elsa do
 
   defdelegate delete_topic(endpoints, topic), to: Elsa.Topic, as: :delete
 
-  defdelegate produce_sync(endpoints, topic, partition, key, value), to: Elsa.Producer, as: :produce_sync_simple
+  defdelegate produce_sync(endpoints, topic, partition, key, value), to: Elsa.Producer, as: :produce_sync
 
   def fetch() do
   end

--- a/lib/elsa.ex
+++ b/lib/elsa.ex
@@ -13,16 +13,12 @@ defmodule Elsa do
 
   defdelegate delete_topic(endpoints, topic), to: Elsa.Topic, as: :delete
 
-  defdelegate produce_sync(endpoints, topic, partition, key, value), to: Elsa.Producer
-
-  defdelegate produce_sync(pid, key, value), to: Elsa.Producer
+  defdelegate produce_sync(endpoints, topic, partition, key, value), to: Elsa.Producer, as: :produce_sync_simple
 
   def fetch() do
   end
 
-  def default_client() do
-    :elsa_default_client
-  end
+  def default_client(), do: :elsa_default_client
 
   defmodule ConnectError do
     defexception [:message]

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -1,4 +1,6 @@
 defmodule Elsa.Producer do
+  use GenServer
+
   def produce_sync(endpoints, topic, partition, key, value) do
     endpoints
     |> Elsa.Util.reformat_endpoints()
@@ -7,4 +9,42 @@ defmodule Elsa.Producer do
     :brod.start_producer(Elsa.default_client(), topic, [])
     :brod.produce_sync(Elsa.default_client(), topic, partition, key, value)
   end
+
+  def produce_sync(name, key, value) do
+    GenServer.call(name, {:produce_sync, key, value})
+  end
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def init(args) do
+    brokers = Keyword.get(args, :brokers)
+    topic = Keyword.get(args, :topic)
+    partition = Keyword.get(args, :partition)
+    client = Elsa.default_client()
+
+    brokers
+    |> Elsa.Util.reformat_endpoints()
+    |> :brod.start_client(client)
+
+    :brod.start_producer(client, topic, [])
+
+    {:ok, {client, topic, partition}, {:continue, :get_producer}}
+  end
+
+  def handle_continue(:get_producer, {client, topic, partition}) do
+    {:ok, pid} = :brod.get_producer(client, topic, partition)
+    {:noreply, pid}
+  end
+
+  def handle_call({:produce_sync, key, value}, _from, pid) do
+    pid
+    |> :brod.produce_sync(key, value)
+    |> reply(pid)
+  end
+
+  defp reply(:ok, pid), do: {:reply, :ok, pid}
+  defp reply(error, pid), do: {:reply, error, pid}
 end

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -4,13 +4,6 @@ defmodule Elsa.Producer do
   as well as send messages to topics.
   """
 
-  def produce_sync_simple(endpoints, topic, partition, key, value) do
-    client = Elsa.default_client()
-
-    start_producer(endpoints, topic, name: client)
-    produce_sync(client, topic, partition, key, value)
-  end
-
   def start_producer(endpoints, topic, config \\ []) do
     name = Keyword.get(config, :name, Elsa.default_client())
 
@@ -20,7 +13,16 @@ defmodule Elsa.Producer do
 
   def stop_producer(client, topic), do: :brod_client.stop_producer(client, topic)
 
-  def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key, value) do
+  def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key, value)
+
+  def produce_sync(endpoints, topic, partition, key, value) when is_list(endpoints) do
+    client = Elsa.default_client()
+
+    start_producer(endpoints, topic, name: client)
+    produce_sync(client, topic, partition, key, value)
+  end
+
+  def produce_sync(client, topic, partition, key, value) do
     :brod.produce_sync(client, topic, partition, key, value)
   end
 

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -13,7 +13,7 @@ defmodule Elsa.Producer do
 
   def stop_producer(client, topic), do: :brod_client.stop_producer(client, topic)
 
-  def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key, value)
+  def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key \\ "ignored", value)
 
   def produce_sync(endpoints, topic, partition, key, value) when is_list(endpoints) do
     client = Elsa.default_client()

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -1,47 +1,30 @@
 defmodule Elsa.Producer do
-  use GenServer
+  @moduledoc """
+  Defines functions to manage producer supervisors and works,
+  as well as send messages to topics.
+  """
 
-  def produce_sync(endpoints, topic, partition, key, value) do
+  def produce_sync_simple(endpoints, topic, partition, key, value) do
     client = Elsa.default_client()
 
-    start_producer(client, endpoints, topic)
+    start_producer(endpoints, topic, name: client)
+    produce_sync(client, topic, partition, key, value)
+  end
+
+  def start_producer(endpoints, topic, config \\ []) do
+    name = Keyword.get(config, :name, Elsa.default_client())
+
+    start_client(endpoints, name)
+    :brod.start_producer(name, topic, config)
+  end
+
+  def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key, value) do
     :brod.produce_sync(client, topic, partition, key, value)
   end
 
-  def produce_sync(name, key, value) do
-    GenServer.call(name, {:produce_sync, key, value})
-  end
-
-  def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
-
-  def init(args) do
-    brokers = Keyword.get(args, :brokers)
-    topic = Keyword.get(args, :topic)
-    partition = Keyword.get(args, :partition)
-    client = Elsa.default_client()
-
-    start_producer(client, brokers, topic)
-
-    {:ok, _pid} = :brod.get_producer(client, topic, partition)
-  end
-
-  def handle_call({:produce_sync, key, value}, _from, pid) do
-    pid
-    |> :brod.produce_sync(key, value)
-    |> reply(pid)
-  end
-
-  defp start_producer(client, brokers, topic) do
-    brokers
+  defp start_client(endpoints, name) do
+    endpoints
     |> Elsa.Util.reformat_endpoints()
-    |> :brod.start_client(client)
-
-    :brod.start_producer(client, topic, [])
+    |> :brod.start_client(name)
   end
-
-  defp reply(:ok, pid), do: {:reply, :ok, pid}
-  defp reply(error, pid), do: {:reply, error, pid}
 end

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -18,6 +18,8 @@ defmodule Elsa.Producer do
     :brod.start_producer(name, topic, config)
   end
 
+  def stop_producer(client, topic), do: :brod_client.stop_producer(client, topic)
+
   def produce_sync(client \\ Elsa.default_client(), topic, partition \\ 0, key, value) do
     :brod.produce_sync(client, topic, partition, key, value)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Elsa.MixProject do
 
   defp package do
     [
-      maintainers: ["Brian Balser", "Jeff Grunewald"],
+      maintainers: ["Brian Balser", "Jeff Grunewald", "Johnson Denen"],
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => "https://github.com/bbalser/elsa"}
     ]

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -12,7 +12,8 @@ defmodule Elsa.ProducerTest do
 
       {:ok, partitions} = :brod.get_partitions_count(:elsa_client1, "elsa-topic")
 
-      producer_pids = Enum.map(0..partitions - 1, fn part -> :brod.get_producer(:elsa_client1, "elsa-topic", part) end)
+      producer_pids =
+        Enum.map(0..(partitions - 1), fn part -> :brod.get_producer(:elsa_client1, "elsa-topic", part) end)
 
       all_alive = Enum.map(producer_pids, fn {_, pid} -> Process.alive?(pid) end)
       assert Enum.all?(all_alive, fn alive -> alive == true end)
@@ -29,7 +30,7 @@ defmodule Elsa.ProducerTest do
       Elsa.create_topic(@brokers, "producer-topic1")
       Elsa.Producer.start_producer(@brokers, "producer-topic1")
 
-      Producer.produce_sync("producer-topic1", "ignored", [{"key1", "value1"}, {"key2", "value2"}])
+      Producer.produce_sync("producer-topic1", [{"key1", "value1"}, {"key2", "value2"}])
 
       parsed_messages = retrieve_results(@brokers, "producer-topic1", 0, 0)
 

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -1,0 +1,29 @@
+defmodule Elsa.ProducerTest do
+  use ExUnit.Case
+  use Divo
+  alias Elsa.Producer
+  require Elsa
+
+  @brokers [{'localhost', 9092}]
+
+  test "produces to preconfigured broker, topic, partition" do
+    Elsa.create_topic(@brokers, "produce-topic-1")
+
+    {:ok, _} =
+      Producer.start_link(
+        name: :producer1,
+        brokers: @brokers,
+        topic: "produce-topic-1",
+        partition: 0
+      )
+
+    Producer.produce_sync(:producer1, "key1", "value1")
+    Producer.produce_sync(:producer1, "key2", "value2")
+
+    {:ok, {_count, messages}} = :brod.fetch(@brokers, "produce-topic-1", 0, 0)
+    parsed_messages =
+      Enum.map(messages, fn msg -> {Elsa.kafka_message(msg, :key), Elsa.kafka_message(msg, :value)} end)
+
+    assert [{"key1", "value1"}, {"key2", "value2"}] == parsed_messages
+  end
+end

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -6,6 +6,24 @@ defmodule Elsa.ProducerTest do
 
   @brokers [{'localhost', 9092}]
 
+  describe "producer supervisors" do
+    test "starts and stops the requested producer supervisor" do
+      Elsa.Producer.start_producer(@brokers, "elsa-topic", name: :elsa_client1)
+
+      {:ok, partitions} = :brod.get_partitions_count(:elsa_client1, "elsa-topic")
+
+      producer_pids = Enum.map(0..partitions - 1, fn part -> :brod.get_producer(:elsa_client1, "elsa-topic", part) end)
+
+      all_alive = Enum.map(producer_pids, fn {_, pid} -> Process.alive?(pid) end)
+      assert Enum.all?(all_alive, fn alive -> alive == true end)
+
+      Elsa.Producer.stop_producer(:elsa_client1, "elsa-topic")
+
+      all_stopped = Enum.map(producer_pids, fn {_, pid} -> Process.alive?(pid) end)
+      assert Enum.all?(all_stopped, fn alive -> alive == false end)
+    end
+  end
+
   describe "preconfigured broker" do
     test "produces to topic with default client and partition" do
       Elsa.create_topic(@brokers, "producer-topic1")
@@ -20,9 +38,9 @@ defmodule Elsa.ProducerTest do
 
     test "produces to topic with named client and partition" do
       Elsa.create_topic(@brokers, "producer-topic2", partitions: 2)
-      Elsa.Producer.start_producer(@brokers, "producer-topic2", name: :elsa_client)
+      Elsa.Producer.start_producer(@brokers, "producer-topic2", name: :elsa_client2)
 
-      Producer.produce_sync(:elsa_client, "producer-topic2", 1, "ignored", [{"key1", "value1"}, {"key2", "value2"}])
+      Producer.produce_sync(:elsa_client2, "producer-topic2", 1, "ignored", [{"key1", "value1"}, {"key2", "value2"}])
 
       parsed_messages = retrieve_results(@brokers, "producer-topic2", 1, 0)
 

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -6,24 +6,45 @@ defmodule Elsa.ProducerTest do
 
   @brokers [{'localhost', 9092}]
 
-  test "produces to preconfigured broker, topic, partition" do
-    Elsa.create_topic(@brokers, "produce-topic-1")
+  describe "preconfigured broker" do
+    test "produces to topic with default client and partition" do
+      Elsa.create_topic(@brokers, "producer-topic1")
+      Elsa.Producer.start_producer(@brokers, "producer-topic1")
 
-    {:ok, _} =
-      Producer.start_link(
-        name: :producer1,
-        brokers: @brokers,
-        topic: "produce-topic-1",
-        partition: 0
-      )
+      Producer.produce_sync("producer-topic1", "ignored", [{"key1", "value1"}, {"key2", "value2"}])
 
-    Producer.produce_sync(:producer1, "key1", "value1")
-    Producer.produce_sync(:producer1, "key2", "value2")
+      parsed_messages = retrieve_results(@brokers, "producer-topic1", 0, 0)
 
-    {:ok, {_count, messages}} = :brod.fetch(@brokers, "produce-topic-1", 0, 0)
-    parsed_messages =
-      Enum.map(messages, fn msg -> {Elsa.kafka_message(msg, :key), Elsa.kafka_message(msg, :value)} end)
+      assert [{"key1", "value1"}, {"key2", "value2"}] == parsed_messages
+    end
 
-    assert [{"key1", "value1"}, {"key2", "value2"}] == parsed_messages
+    test "produces to topic with named client and partition" do
+      Elsa.create_topic(@brokers, "producer-topic2", partitions: 2)
+      Elsa.Producer.start_producer(@brokers, "producer-topic2", name: :elsa_client)
+
+      Producer.produce_sync(:elsa_client, "producer-topic2", 1, "ignored", [{"key1", "value1"}, {"key2", "value2"}])
+
+      parsed_messages = retrieve_results(@brokers, "producer-topic2", 1, 0)
+
+      assert [{"key1", "value1"}, {"key2", "value2"}] == parsed_messages
+    end
+  end
+
+  describe "ad hoc produce_sync" do
+    test "produces to the specified topic with no prior broker" do
+      Elsa.create_topic(@brokers, "producer-topic3")
+
+      Elsa.produce_sync(@brokers, "producer-topic3", 0, "ignored", [{"key1", "value1"}, {"key2", "value2"}])
+
+      parsed_messages = retrieve_results(@brokers, "producer-topic3", 0, 0)
+
+      assert [{"key1", "value1"}, {"key2", "value2"}] == parsed_messages
+    end
+  end
+
+  defp retrieve_results(endpoints, topic, partition, offset) do
+    {:ok, {_count, messages}} = :brod.fetch(endpoints, topic, partition, offset)
+
+    Enum.map(messages, fn msg -> {Elsa.kafka_message(msg, :key), Elsa.kafka_message(msg, :value)} end)
   end
 end


### PR DESCRIPTION
Includes additional functionality for producing to topics, either via ad hoc call or to a named client (expected to be running as a producer in an application's supervision tree at startup)