### PR TITLE
Streaming fetch

### DIFF
--- a/lib/elsa/fetch.ex
+++ b/lib/elsa/fetch.ex
@@ -26,65 +26,79 @@ defmodule Elsa.Fetch do
   end
 
   @doc """
-  Retrieves all messages on a given topic partition. Evaluates
-  lazily, returning a `Stream` resource containing the messages.
-  """
-  @spec fetch_partition_stream(keyword(), String.t(), keyword()) :: Enumerable.t()
-  def fetch_partition_stream(endpoints, topic, opts \\ []) do
-    offset = Keyword.get(opts, :offset, 0)
-    partition = Keyword.get(opts, :partition, 0)
-
-    Stream.resource(
-      fn -> offset end,
-      fn offset ->
-        case fetch(endpoints, topic, partition: partition, offset: offset) do
-          {:ok, _partition_offset, messages} ->
-            next_offset = offset + Enum.count(messages)
-            {messages, next_offset}
-
-          {:ok, {_, []}} ->
-            {:halt, offset}
-
-          {:error, _} ->
-            {:halt, offset}
-        end
-      end,
-      fn offset -> offset end
-    )
-  end
-
-  @doc """
-  Retrieves all messages on a given topic across all partitions.
+  Retrieves all messages on a given topic across all partitions by default.
   Evaluates lazily, returning a `Stream` resource containing the messages.
+  By default the starting offset is the earliest message offset and fetching
+  continues until the latest offset at the time the stream is instantiated.
+  Refine the scope of stream fetch by passing the `start_offset` and `end_offset`
+  keyword arguments.
   """
-  @spec fetch_topic_stream(keyword(), String.t(), keyword()) :: Enumerable.t()
-  def fetch_topic_stream(endpoints, topic, opts \\ []) do
-    offset = Keyword.get(opts, :offset, 0)
-    partitions = Elsa.Util.partition_count(endpoints, topic) - 1
+  @spec fetch_stream(keyword(), String.t(), keyword()) :: Enumerable.t()
+  def fetch_stream(endpoints, topic, opts \\ []) do
+    partitions =
+      case Keyword.get(opts, :partition) do
+        nil ->
+          0..(Elsa.Util.partition_count(endpoints, topic) - 1)
 
-    Enum.reduce(0..partitions, [], fn partition, acc ->
-      partition_stream = fetch_partition_stream(endpoints, topic, partition: partition, offset: offset)
+        partition ->
+          [partition]
+      end
+
+    Enum.reduce(partitions, [], fn partition, acc ->
+      partition_stream = fetch_partition_stream(endpoints, topic, partition, opts)
       [partition_stream | acc]
     end)
     |> Stream.concat()
   end
 
   @doc """
-  Retrieves an array of messages containing the supplied search string,
-  sorted by time and with the partition and offset for reference. Search can
-  be limited by an offset and time which are passed through to fetch_all/3 call
+  Retrieves a stream of messages containing the supplied search string. Search
+  can be limited by an offset which is passed through to fetch_stream/3 call
   retrieving the messages to search. By default, the search is applied against
   the message values but can be optionally switched to search on the message key
-  by supplying the `search_by_key: true` option.
+  by supplying the `search_by_key: true` option. All options for fetch_stream/3
+  are respected for restricting the search scope.
   """
   @spec search(keyword(), String.t(), String.t(), keyword()) :: Enumerable.t()
   def search(endpoints, topic, search_term, opts \\ []) do
     search_by = if Keyword.get(opts, :search_by_key), do: :key, else: :value
-    all_messages = fetch_topic_stream(endpoints, topic, opts)
+    all_messages = fetch_stream(endpoints, topic, opts)
 
     Stream.filter(all_messages, fn message ->
       search_by(message, search_term, search_by)
     end)
+  end
+
+  defp fetch_partition_stream(endpoints, topic, partition, opts) do
+    Stream.resource(
+      fn ->
+        start_offset =
+          Keyword.get_lazy(opts, :start_offset, fn ->
+            {:ok, earliest} = :brod.resolve_offset(endpoints, topic, partition, :earliest)
+            earliest
+          end)
+
+        end_offset =
+          Keyword.get_lazy(opts, :end_offset, fn ->
+            {:ok, latest} = :brod.resolve_offset(endpoints, topic, partition, :latest)
+            latest
+          end)
+
+        {start_offset, end_offset}
+      end,
+      fn {current_offset, end_offset} ->
+        case current_offset < end_offset do
+          true ->
+            {:ok, _offset, messages} = fetch(endpoints, topic, partition: partition, offset: current_offset)
+            next_offset = current_offset + Enum.count(messages)
+            {messages, {next_offset, end_offset}}
+
+          false ->
+            {:halt, {current_offset, end_offset}}
+        end
+      end,
+      fn offset -> offset end
+    )
   end
 
   defp unwrap_messages({_, offset, key, value, _, time, _}, partition), do: {partition, offset, key, value, time}

--- a/lib/elsa/fetch.ex
+++ b/lib/elsa/fetch.ex
@@ -72,17 +72,8 @@ defmodule Elsa.Fetch do
   defp fetch_partition_stream(endpoints, topic, partition, opts) do
     Stream.resource(
       fn ->
-        start_offset =
-          Keyword.get_lazy(opts, :start_offset, fn ->
-            {:ok, earliest} = :brod.resolve_offset(endpoints, topic, partition, :earliest)
-            earliest
-          end)
-
-        end_offset =
-          Keyword.get_lazy(opts, :end_offset, fn ->
-            {:ok, latest} = :brod.resolve_offset(endpoints, topic, partition, :latest)
-            latest
-          end)
+        start_offset = retrieve_offset(opts, :start_offset, endpoints, topic, partition)
+        end_offset = retrieve_offset(opts, :end_offset, endpoints, topic, partition)
 
         {start_offset, end_offset}
       end,
@@ -112,5 +103,19 @@ defmodule Elsa.Fetch do
     normalized_search = String.downcase(search)
 
     String.contains?(normalized_term, normalized_search)
+  end
+
+  defp retrieve_offset(opts, :start_offset, endpoints, topic, partition) do
+    Keyword.get_lazy(opts, :start_offset, fn ->
+      {:ok, start_offset} = :brod.resolve_offset(endpoints, topic, partition, :earliest)
+      start_offset
+    end)
+  end
+
+  defp retrieve_offset(opts, :end_offset, endpoints, topic, partition) do
+    Keyword.get_lazy(opts, :end_offset, fn ->
+      {:ok, end_offset} = :brod.resolve_offset(endpoints, topic, partition, :latest)
+      end_offset
+    end)
   end
 end

--- a/lib/elsa/producer.ex
+++ b/lib/elsa/producer.ex
@@ -70,7 +70,7 @@ defmodule Elsa.Producer do
     |> Enum.each(fn chunk -> :brod.produce_sync(client, topic, partition, "", chunk) end)
   end
 
-  defp wrap_with_key({key, value} = message), do: message
+  defp wrap_with_key({_key, _value} = message), do: message
   defp wrap_with_key(message), do: {"", message}
 
   defp get_client(opts) do

--- a/test/integration/elsa/fetch_test.exs
+++ b/test/integration/elsa/fetch_test.exs
@@ -10,7 +10,7 @@ defmodule Elsa.FetchTest do
       Elsa.produce(@endpoints, "fetch1", [{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}])
 
       {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch1")
-      result = Enum.map(messages, fn {_offset, _key, value} -> value end)
+      result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
 
       assert 3 == offset
       assert 3 == Enum.count(messages)
@@ -23,7 +23,7 @@ defmodule Elsa.FetchTest do
       Elsa.produce(@endpoints, "fetch2", [{"key3", "value3"}, {"key4", "value4"}], partition: 1)
 
       {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch2", partition: 1)
-      result = Enum.map(messages, fn {_offset, _key, value} -> value end)
+      result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
 
       assert 2 == offset
       assert 2 == Enum.count(messages)
@@ -31,87 +31,70 @@ defmodule Elsa.FetchTest do
     end
   end
 
-  describe "fetch_all/3" do
+  describe "fetch_topic_stream/3" do
     test "fetches all messages from the topic" do
       Elsa.create_topic(@endpoints, "fetch3", partitions: 2)
       Elsa.produce(@endpoints, "fetch3", [{"key1", "value1"}, {"key2", "value2"}], partition: 0)
       Elsa.produce(@endpoints, "fetch3", [{"key3", "value3"}, {"key4", "value4"}], partition: 1)
 
-      messages = Elsa.Fetch.fetch_all(@endpoints, "fetch3")
-      result = Enum.map(messages, fn {_timestamp, _partition, _offset, _key, value} -> value end)
+      messages = Elsa.Fetch.fetch_partition_stream(@endpoints, "fetch3") |> Enum.to_list()
+      result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
 
       assert 4 == Enum.count(messages)
       assert ["value1", "value2", "value3", "value4"] == result
     end
-
-    test "fetches all messages from the topic after the time offset" do
-      Elsa.create_topic(@endpoints, "fetch4", partitions: 2)
-      Elsa.produce(@endpoints, "fetch4", [{"key1", "value1"}], partition: 0)
-      Elsa.produce(@endpoints, "fetch4", [{"key2", "value2"}], partition: 1)
-
-      time_marker = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-
-      Elsa.produce(@endpoints, "fetch4", [{"key3", "value3"}], partition: 0)
-      Elsa.produce(@endpoints, "fetch4", [{"key4", "value4"}], partition: 1)
-
-      messages = Elsa.Fetch.fetch_all(@endpoints, "fetch4", time: time_marker)
-      result = Enum.map(messages, fn {_timestamp, partition, _offset, _key, value} -> {partition, value} end)
-
-      assert 2 == Enum.count(messages)
-      assert [{0, "value3"}, {1, "value4"}] == result
-    end
   end
 
-  describe "search/4" do
-    test "finds specified message by value" do
-      Elsa.create_topic(@endpoints, "search1", partitions: 2)
+  # describe "search/4" do
+  #   test "finds specified message by value" do
+  #     Elsa.create_topic(@endpoints, "search1", partitions: 2)
 
-      Elsa.produce(@endpoints, "search1", [{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}],
-        partitioner: :random
-      )
+  #     Elsa.produce(@endpoints, "search1", [{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}],
+  #       partitioner: :random
+  #     )
 
-      message = Elsa.Fetch.search(@endpoints, "search1", "value2")
-      result = Enum.map(message, fn {_, _, _, key, value} -> {key, value} end)
+  #     message = Elsa.Fetch.search(@endpoints, "search1", "value2")
+  #     result = Enum.map(message, fn {_, _, _, key, value} -> {key, value} end)
 
-      assert [{"key2", "value2"}] == result
-    end
+  #     assert [{"key2", "value2"}] == result
+  #   end
 
-    test "finds specified message by key" do
-      Elsa.create_topic(@endpoints, "search2", partitions: 2)
+  #   test "finds specified message by key" do
+  #     Elsa.create_topic(@endpoints, "search2", partitions: 2)
 
-      Elsa.produce(@endpoints, "search2", [{"key1", "value1"}, {"foo", "value2"}, {"key3", "value3"}],
-        partitioner: :random
-      )
+  #     Elsa.produce(@endpoints, "search2", [{"key1", "value1"}, {"foo", "value2"}, {"key3", "value3"}],
+  #       partitioner: :random
+  #     )
 
-      messages = Elsa.Fetch.search(@endpoints, "search2", "key", search_by_key: true)
-      result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
+  #     messages = Elsa.Fetch.search(@endpoints, "search2", "key", search_by_key: true)
+  #     result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
 
-      for message <- result, do: assert(message in [{"key1", "value1"}, {"key3", "value3"}])
-    end
+  #     for message <- result, do: assert(message in [{"key1", "value1"}, {"key3", "value3"}])
+  #   end
 
-    test "finds specified message filtered by time" do
-      Elsa.create_topic(@endpoints, "search3", partitions: 2)
-      Elsa.produce(@endpoints, "search3", [{"key1", "value1"}, {"key2", "value2"}], partitioner: :random)
+  #   test "finds specified message filtered by time" do
+  #     Elsa.create_topic(@endpoints, "search3", partitions: 2)
+  #     Elsa.produce(@endpoints, "search3", [{"key1", "value1"}, {"key2", "value2"}], partitioner: :random)
 
-      time_marker = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+  #     time_marker = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
-      Elsa.produce(@endpoints, "search3", [{"key3", "value3"}, {"key4", "value4"}], partitioner: :random)
+  #     Elsa.produce(@endpoints, "search3", [{"key3", "value3"}, {"key4", "value4"}], partitioner: :random)
 
-      messages = Elsa.Fetch.search(@endpoints, "search3", "key", time: time_marker, search_by_key: true)
-      result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
+  #     messages = Elsa.Fetch.search(@endpoints, "search3", "key", time: time_marker, search_by_key: true)
+  #     result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
 
-      for message <- result, do: assert(message in [{"key3", "value3"}, {"key4", "value4"}])
-    end
+  #     for message <- result, do: assert(message in [{"key3", "value3"}, {"key4", "value4"}])
+  #   end
 
-    test "returns empty list when no match is found" do
-      Elsa.create_topic(@endpoints, "search4")
-      Elsa.produce(@endpoints, "search4", [{"key", "value"}])
+  #   test "returns empty list when no match is found" do
+  #     Elsa.create_topic(@endpoints, "search4")
+  #     Elsa.produce(@endpoints, "search4", [{"key", "value"}])
 
-      value_result = Elsa.Fetch.search(@endpoints, "search4", "foo")
-      key_result = Elsa.Fetch.search(@endpoints, "search4", "bar")
+  #     value_result = Elsa.Fetch.search(@endpoints, "search4", "foo")
+  #     key_result = Elsa.Fetch.search(@endpoints, "search4", "bar")
 
-      assert value_result == []
-      assert key_result == []
-    end
-  end
+  #     assert value_result == []
+  #     assert key_result == []
+  #   end
+  # end
 end

--- a/test/integration/elsa/fetch_test.exs
+++ b/test/integration/elsa/fetch_test.exs
@@ -4,97 +4,98 @@ defmodule Elsa.FetchTest do
 
   @endpoints [localhost: 9092]
 
+  setup_all do
+    Elsa.create_topic(@endpoints, "fetch-tests", partitions: 3)
+
+    Enum.map([0, 1, 2], fn partition ->
+      messages = Enum.map(1..10, &construct_message(&1, partition))
+      Elsa.produce(@endpoints, "fetch-tests", messages, partition: partition)
+    end)
+
+    :ok
+  end
+
   describe "fetch/3" do
     test "fetches from the default offset and partition" do
-      Elsa.create_topic(@endpoints, "fetch1")
-      Elsa.produce(@endpoints, "fetch1", [{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}])
-
-      {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch1")
+      {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch-tests")
       result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
 
-      assert 3 == offset
-      assert 3 == Enum.count(messages)
-      assert ["value1", "value2", "value3"] == result
+      assert 10 == offset
+      assert ["val1", "val2", "val3", "val4", "val5", "val6", "val7", "val8", "val9", "val10"] == result
     end
 
     test "fetches from the specified offset and partition" do
-      Elsa.create_topic(@endpoints, "fetch2", partitions: 2)
-      Elsa.produce(@endpoints, "fetch2", [{"key1", "value1"}, {"key2", "value2"}])
-      Elsa.produce(@endpoints, "fetch2", [{"key3", "value3"}, {"key4", "value4"}], partition: 1)
-
-      {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch2", partition: 1)
+      {:ok, offset, messages} = Elsa.fetch(@endpoints, "fetch-tests", partition: 1, offset: 3)
       result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
 
-      assert 2 == offset
-      assert 2 == Enum.count(messages)
-      assert ["value3", "value4"] == result
+      assert 10 == offset
+      assert ["val14", "val15", "val16", "val17", "val18", "val19", "val20"] == result
     end
   end
 
-  describe "fetch_topic_stream/3" do
-    test "fetches all messages from the topic" do
-      Elsa.create_topic(@endpoints, "fetch3", partitions: 2)
-      Elsa.produce(@endpoints, "fetch3", [{"key1", "value1"}, {"key2", "value2"}], partition: 0)
-      Elsa.produce(@endpoints, "fetch3", [{"key3", "value3"}, {"key4", "value4"}], partition: 1)
+  describe "fetch_stream/3" do
+    test "fetches all messages from the specified partition" do
+      result =
+        Elsa.Fetch.fetch_stream(@endpoints, "fetch-tests", partition: 2)
+        |> Enum.map(fn {_partition, _offset, _key, value, _timestamp} -> value end)
+        |> Enum.sort()
 
-      messages = Elsa.Fetch.fetch_partition_stream(@endpoints, "fetch3") |> Enum.to_list()
-      result = Enum.map(messages, fn {_partition, _offset, _key, value, _timestamp} -> value end)
+      expected = Enum.map(21..30, fn num -> "val#{num}" end) |> Enum.sort()
 
-      assert 4 == Enum.count(messages)
-      assert ["value1", "value2", "value3", "value4"] == result
+      assert expected == result
+    end
+
+    test "fetches all messages from the topic across all partitions" do
+      result =
+        Elsa.Fetch.fetch_stream(@endpoints, "fetch-tests")
+        |> Enum.map(fn {_partition, _offset, _key, value, _timestamp} -> value end)
+        |> Enum.sort()
+
+      expected = Enum.map(1..30, fn num -> "val#{num}" end) |> Enum.sort()
+
+      assert expected == result
+    end
+
+    test "fetches all messages across partitions since the specified offset" do
+      result =
+        Elsa.Fetch.fetch_stream(@endpoints, "fetch-tests", start_offset: 9)
+        |> Enum.map(fn {_partition, _offset, _key, value, _timestamp} -> value end)
+        |> Enum.sort()
+
+      expected = ["val10", "val20", "val30"]
+
+      assert expected == result
     end
   end
 
-  # describe "search/4" do
-  #   test "finds specified message by value" do
-  #     Elsa.create_topic(@endpoints, "search1", partitions: 2)
+  describe "search/4" do
+    test "finds specified message by value" do
+      message = Elsa.Fetch.search(@endpoints, "fetch-tests", "val19")
+      result = Enum.map(message, fn {_, _, key, value, _} -> {key, value} end)
 
-  #     Elsa.produce(@endpoints, "search1", [{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}],
-  #       partitioner: :random
-  #     )
+      assert [{"key19", "val19"}] == result
+    end
 
-  #     message = Elsa.Fetch.search(@endpoints, "search1", "value2")
-  #     result = Enum.map(message, fn {_, _, _, key, value} -> {key, value} end)
+    test "finds specified message by key" do
+      messages = Elsa.Fetch.search(@endpoints, "fetch-tests", "key2", search_by_key: true)
+      result = Enum.map(messages, fn {_, _, key, value, _} -> {key, value} end)
 
-  #     assert [{"key2", "value2"}] == result
-  #   end
+      expected = [{"key2", "val2"} | Enum.map(20..29, fn num -> {"key#{num}", "val#{num}"} end)]
 
-  #   test "finds specified message by key" do
-  #     Elsa.create_topic(@endpoints, "search2", partitions: 2)
+      for message <- result, do: assert(message in expected)
+    end
 
-  #     Elsa.produce(@endpoints, "search2", [{"key1", "value1"}, {"foo", "value2"}, {"key3", "value3"}],
-  #       partitioner: :random
-  #     )
+    test "returns empty list when no match is found" do
+      value_result = Elsa.Fetch.search(@endpoints, "fetch-tests", "foo") |> Enum.to_list()
+      key_result = Elsa.Fetch.search(@endpoints, "fetch-tests", "bar", search_by_key: true) |> Enum.to_list()
 
-  #     messages = Elsa.Fetch.search(@endpoints, "search2", "key", search_by_key: true)
-  #     result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
+      assert value_result == []
+      assert key_result == []
+    end
+  end
 
-  #     for message <- result, do: assert(message in [{"key1", "value1"}, {"key3", "value3"}])
-  #   end
-
-  #   test "finds specified message filtered by time" do
-  #     Elsa.create_topic(@endpoints, "search3", partitions: 2)
-  #     Elsa.produce(@endpoints, "search3", [{"key1", "value1"}, {"key2", "value2"}], partitioner: :random)
-
-  #     time_marker = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-
-  #     Elsa.produce(@endpoints, "search3", [{"key3", "value3"}, {"key4", "value4"}], partitioner: :random)
-
-  #     messages = Elsa.Fetch.search(@endpoints, "search3", "key", time: time_marker, search_by_key: true)
-  #     result = Enum.map(messages, fn {_, _, _, key, value} -> {key, value} end)
-
-  #     for message <- result, do: assert(message in [{"key3", "value3"}, {"key4", "value4"}])
-  #   end
-
-  #   test "returns empty list when no match is found" do
-  #     Elsa.create_topic(@endpoints, "search4")
-  #     Elsa.produce(@endpoints, "search4", [{"key", "value"}])
-
-  #     value_result = Elsa.Fetch.search(@endpoints, "search4", "foo")
-  #     key_result = Elsa.Fetch.search(@endpoints, "search4", "bar")
-
-  #     assert value_result == []
-  #     assert key_result == []
-  #   end
-  # end
+  defp construct_message(num, multiplier) do
+    index = num + 10 * multiplier
+    {"key#{index}", "val#{index}"}
+  end
 end


### PR DESCRIPTION
Converts fetch_all function to produce a streaming for arbitrarily large message streams. Continues to allow filtering of messages by offset.

Also handles the setting of message offsets in requests in the event the retained messages being fetched/searched have shifted beyond the original (zero index) and bounds the last offset retrieved in the event messages are streaming as fast or faster than fetching can process.