### PR TITLE
Added some documentation to group manager

### DIFF
--- a/test/integration/elsa/group/consumer_test.exs
+++ b/test/integration/elsa/group/consumer_test.exs
@@ -10,7 +10,7 @@ defmodule Elsa.Group.ConsumerTest do
     {:ok, pid} =
       Elsa.Group.Supervisor.start_link(
         name: :name1,
-        brokers: @brokers,
+        endpoints: @brokers,
         group: "group1",
         topics: ["elsa-topic"],
         handler: Testing.ExampleMessageHandlerWithState,


### PR DESCRIPTION
Do we prefer using type to document configuration or do we prefer to explain all the config options in a doc comment for the start_link function??