### PR TITLE
Revise docs of begin_offset

### DIFF
--- a/lib/elsa/supervisor.ex
+++ b/lib/elsa/supervisor.ex
@@ -75,7 +75,7 @@ defmodule Elsa.Supervisor do
 
   * `:topic` - Required. Topic to subscribe to.
 
-  * `:begin_offset` - Required. Where to begin consuming from the topic. Must be either `:earliest`, `:latest`, or a valid offset integer.
+  * `:begin_offset` - Required. Where to begin consuming from. Must be either `:earliest`, `:latest`, or a valid offset integer.
 
   * `:handler` - Required. Module that implements `Elsa.Consumer.MessageHandler` behaviour.
 


### PR DESCRIPTION
Offsets are per partition.

I am not sure if it makes sense to set `begin_offset` to an integer if the consumer is processing several partitions, but I guess the docs can remain as they are for the use case in which there is only one partition.