### PR TITLE
Ensure that starting offset is used on worker restart if acknowledger…

### DIFF
--- a/lib/elsa/group/acknowledger.ex
+++ b/lib/elsa/group/acknowledger.ex
@@ -43,7 +43,7 @@ defmodule Elsa.Group.Acknowledger do
   Retrieve the latest offset for a topic and partition. Primarily used for reinitializing
   consumer workers to the latest unacknowledged offset after a rebalance or other disruption.
   """
-  @spec get_latest_offset(GenServer.server(), Elsa.topic(), Elsa.partition()) :: Elsa.Group.Manager.begin_offset()
+  @spec get_latest_offset(GenServer.server(), Elsa.topic(), Elsa.partition()) :: Elsa.Group.Manager.begin_offset() | nil
   def get_latest_offset(acknowledger, topic, partition) do
     GenServer.call(acknowledger, {:get_latest_offset, topic, partition})
   end

--- a/lib/elsa/group/manager/worker_manager.ex
+++ b/lib/elsa/group/manager/worker_manager.ex
@@ -57,7 +57,7 @@ defmodule Elsa.Group.Manager.WorkerManager do
         {:via, Elsa.Registry, {registry(state.connection), Elsa.Group.Acknowledger}},
         worker.topic,
         worker.partition
-      )
+      ) || worker.latest_offset
 
     assignment = brod_received_assignment(topic: worker.topic, partition: worker.partition, begin_offset: latest_offset)
 


### PR DESCRIPTION
… has no

offset recorded