### PR TITLE
Allow users to create compacted topics

### DIFF
--- a/lib/elsa/topic.ex
+++ b/lib/elsa/topic.ex
@@ -45,12 +45,17 @@ defmodule Elsa.Topic do
   @spec create(keyword(), String.t(), keyword()) :: :ok | {:error, term()}
   def create(endpoints, topic, opts \\ []) do
     with_connection(endpoints, :controller, fn connection ->
+      config =
+        opts
+        |> Keyword.get(:config, [])
+        |> Enum.map(fn {key, val} -> %{config_key: to_string(key), config_value: val} end)
+
       create_topic_args = %{
         topic: topic,
         num_partitions: Keyword.get(opts, :partitions, 1),
         replication_factor: Keyword.get(opts, :replicas, 1),
         replica_assignment: [],
-        config_entries: []
+        config_entries: config
       }
 
       version = Elsa.Util.get_api_version(connection, :create_topics)


### PR DESCRIPTION
This PR introduces the ability to mark a topic as compacted. I'm on the fence about this specific implementation. It works for this one scenario, but it might be better to allow users to specify arbitrary configuration values. Maybe something like this:

```elixir
create_topic(endpoint, "foo", config: [{"cleanup.policy", "compact"}])
```

Internally, Elsa would have to convert these values into the map that kpro expects. I think this API is probably less convenient but more powerful in the long run. But I thought I would get a discussion started with the simple version.