### PR TITLE
Don't exit consumer process that doesn't exist

### DIFF
--- a/lib/elsa/consumer/worker.ex
+++ b/lib/elsa/consumer/worker.ex
@@ -128,6 +128,10 @@ defmodule Elsa.Consumer.Worker do
     {:stop, reason, state}
   end
 
+  def terminate(_reason, %{consumer_pid: nil} = state) do
+    state
+  end
+
   def terminate(reason, state) do
     :brod_consumer.unsubscribe(state.consumer_pid, self())
     Process.exit(state.consumer_pid, reason)


### PR DESCRIPTION
In the subscription callback, we can fail because the consumer can't be started. This falls eventually to the terminate callback, which tries to exit a non-existent consumer process (`state.consumer_pid == nil`).

Not a big deal really, since blowing up in the terminate callback gets the job done, but it does add noise and a potential red herring to anyone trying to troubleshoot another issue.