### PR TITLE
Add producer processes to an established connection

### DIFF
--- a/lib/elsa/supervisor.ex
+++ b/lib/elsa/supervisor.ex
@@ -136,13 +136,13 @@ defmodule Elsa.Supervisor do
 
   * `:config` - Optional. Producer configuration options passed to `brod_producer`.
   """
-  @spec start_producer(String.t() | atom, keyword) :: :ok
+  @spec start_producer(String.t() | atom, keyword) :: [DynamicSupervisor.on_start_child()]
   def start_producer(connection, args) do
     registry = registry(connection)
     process_manager = via_name(registry, :producer_process_manager)
 
     Elsa.Producer.Initializer.init(registry, args)
-    |> Enum.each(&Elsa.DynamicProcessManager.start_child(process_manager, &1))
+    |> Enum.map(&Elsa.DynamicProcessManager.start_child(process_manager, &1))
   end
 
   def init(args) do

--- a/lib/elsa/supervisor.ex
+++ b/lib/elsa/supervisor.ex
@@ -120,12 +120,7 @@ defmodule Elsa.Supervisor do
   """
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(args) do
-    opts =
-      case Keyword.has_key?(args, :name) do
-        true -> [name: Keyword.fetch!(args, :name)]
-        false -> []
-      end
-
+    opts = Keyword.take(args, [:name])
     Supervisor.start_link(__MODULE__, args, opts)
   end
 

--- a/test/integration/elsa/producer_test.exs
+++ b/test/integration/elsa/producer_test.exs
@@ -220,7 +220,6 @@ defmodule Elsa.ProducerTest do
       )
 
       Elsa.Supervisor.start_producer(connection, topic: topic1)
-      Process.sleep(10_000)
 
       patient_produce(connection, topic1, {"key1", "value1"}, [])
 
@@ -228,7 +227,6 @@ defmodule Elsa.ProducerTest do
       assert {"key1", "value1"} in messages
 
       Elsa.Supervisor.start_producer(connection, topic: topic2)
-      Process.sleep(10_000)
 
       patient_produce(connection, topic2, {"key2", "value2"}, [])
 
@@ -260,7 +258,7 @@ defmodule Elsa.ProducerTest do
         end
       end,
       dwell: 100,
-      max_retries: 5
+      max_retries: 50
     )
   end
 
@@ -273,8 +271,4 @@ end
 
 defmodule Testing.SuperSimpleMessageHandler do
   use Elsa.Consumer.MessageHandler
-
-  def handle_messages(_messages) do
-    :ack
-  end
 end


### PR DESCRIPTION
Closes #78 

Producer processes can be added to a pre-established Elsa connection with `Elsa.Supervisor.start_producer/2`.

### Example

```elixir
{:ok, _sup} = 
  Elsa.Supervisor.start_link(
    endpoints: [localhost: 9092],
    connection: :my_connection_name,
    group_consumer: [
      group: "my_connection_group_consumer_name",
      topics: ["read-from-topic"],
      handler: My.MessageHandler
    ]
  )

Elsa.Supervisor.start_producer(:my_connection_name, topic: "write-to-topic")

Elsa.Producer.produce(:my_connection_name, "write-to-topic", [{"key", "value"}]) # not an ad-hoc produce
```

### Polling

The biggest change here is that an `Elsa.DynamicProcessManager` is ALWAYS started for producers, even if you don't configure Elsa to use producers. And partition polling for producers is determined when the `Elsa.Supervisor` for that connection is started. Default is NO POLLING. So if you may want to add dynamic producers that poll, you should tweak that in `start_link` ahead of time:

```elixir
{:ok, _sup} = 
  Elsa.Supervisor.start_link(
    endpoints: [localhost: 9092],
    connection: :some_conn,
    producer: [poll: true],
    group_consumer: [ ... ]
  )
```