### PR TITLE
Always restart non-group worker processes that exited abnormally

### DIFF
--- a/lib/elsa/group/manager/worker_manager.ex
+++ b/lib/elsa/group/manager/worker_manager.ex
@@ -75,6 +75,7 @@ defmodule Elsa.Group.Manager.WorkerManager do
     assignment = Enum.into(brod_received_assignment(assignment), %{})
 
     init_args = [
+      worker_type: :group,
       topic: assignment.topic,
       partition: assignment.partition,
       generation_id: generation_id,

--- a/lib/elsa/supervisor.ex
+++ b/lib/elsa/supervisor.ex
@@ -196,6 +196,7 @@ defmodule Elsa.Supervisor do
 
     consumer_args =
       args
+      |> Keyword.put(:worker_type, :non_group)
       |> Keyword.put(:registry, registry)
       |> Keyword.put(:connection, connection)
       |> Keyword.put(:topics, topics)


### PR DESCRIPTION
The new behaviour is less surprising and consistent with the way group consumer workers behave.

Fixes #104